### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gnoci"
 version = "0.0.1"
 description = "Small OCI image builder"
-homepage = "https://github.com/tofay/gnoci"
+repository = "https://github.com/tofay/gnoci"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION
According to the [manifset](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91